### PR TITLE
Check ISR callback before invoking

### DIFF
--- a/TimerOne.cpp
+++ b/TimerOne.cpp
@@ -26,7 +26,9 @@ void (*TimerOne::isrCallback)() = NULL;
 #if defined(__AVR__)
 ISR(TIMER1_OVF_vect)
 {
-  Timer1.isrCallback();
+  if(Timer1.isrCallback) {
+    Timer1.isrCallback();
+  }
 }
 
 #elif defined(__arm__) && defined(CORE_TEENSY)
@@ -38,7 +40,9 @@ void ftm1_isr(void)
   #else
   if (sc & 0x80) FTM1_SC = sc & 0x7F;
   #endif
-  Timer1.isrCallback();
+  if(Timer1.isrCallback) {
+    Timer1.isrCallback();
+  }
 }
 
 #endif


### PR DESCRIPTION
This fixes an issue where some of our slower boards couldn't finish their startup procedure in time to set the ISR callback appropriately, causing a bootloop.

This simply checks the pointer value before calling it.