### PR TITLE
some improvements

### DIFF
--- a/TimerOne.h
+++ b/TimerOne.h
@@ -84,11 +84,11 @@ class TimerOne
 		TCCR1B = 0; //disable timer (this doesnt seem to stop the interrupt from occuring when setting TCNT1 to 0)
 		bool interruptActive = TIMSK1 & _BV(TOIE1);
 		if (interruptActive) {
-			TIMSK1 = TIMSK1 & ~_BV(TOIE1); //disable timer interrupt
+			bitClear(TIMSK1, TOIE1); //disable timer interrupt
 		}
 		TCNT1 = 0;
 		if (interruptActive) {
-			TIMSK1 = TIMSK1 | _BV(TOIE1); //enable timer interrupt
+			bitSet(TIMSK1, TOIE1); //enable timer interrupt
 		}
 		resume();
 	}

--- a/TimerOne.h
+++ b/TimerOne.h
@@ -80,11 +80,18 @@ class TimerOne
     //****************************
     //  Run Control
     //****************************
-    void start() __attribute__((always_inline)) {
-	TCCR1B = 0;
-	TCNT1 = 0;		// TODO: does this cause an undesired interrupt?
-	resume();
-    }
+	void start() __attribute__((always_inline)) {
+		TCCR1B = 0; //disable timer (this doesnt seem to stop the interrupt from occuring when setting TCNT1 to 0)
+		bool interruptActive = TIMSK1 & _BV(TOIE1);
+		if (interruptActive) {
+			TIMSK1 = TIMSK1 & ~_BV(TOIE1); //disable timer interrupt
+		}
+		TCNT1 = 0;
+		if (interruptActive) {
+			TIMSK1 = TIMSK1 | _BV(TOIE1); //enable timer interrupt
+		}
+		resume();
+	}
     void stop() __attribute__((always_inline)) {
 	TCCR1B = _BV(WGM13);
     }

--- a/TimerOne.h
+++ b/TimerOne.h
@@ -48,7 +48,7 @@ class TimerOne
 	TCCR1A = 0;                 // clear control register A 
 	setPeriod(microseconds);
     }
-    void setPeriod(unsigned long microseconds) __attribute__((always_inline)) {
+    void setPeriod(unsigned long microseconds, bool doRestart = false) __attribute__((always_inline)) {
 	const unsigned long cycles = (F_CPU / 2000000) * microseconds;
 	if (cycles < TIMER1_RESOLUTION) {
 		clockSelectBits = _BV(CS10);
@@ -75,6 +75,9 @@ class TimerOne
 	}
 	ICR1 = pwmPeriod;
 	TCCR1B = _BV(WGM13) | clockSelectBits;
+	if(doRestart){
+		restart();
+	}
     }
 
     //****************************


### PR DESCRIPTION
this is a proposed fix for the unwanted interrupt when calling start. i had no chance to test it as i didnt have this problem, but i think turning off the interrupt should work

i also added an optional argument to the setperiod function. when setting the period you usually also want to reset the timer, but when i did this i never really thought about it, so i put this argument in the function so when looking at the functions code people can see that they mightve forgotten to reset the counter.

also i think the examples dont work, as the timer isnt started, but i didnt change that.