### PR TITLE
Updated version to 1.1.1 in library.properties. New tag 1.1.1 must be created from your side as well.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TimerOne
-version=1.1
+version=1.1.1
 author=Stoyko Dimitrov, Jesse Tane, Jérôme Despatis, Michael Polli, Dan Clemens, Paul Stoffregen
 maintainer=Paul Stoffregen
 sentence=Use hardware Timer1 for finer PWM control and/or running an periodic interrupt function


### PR DESCRIPTION
Updated version to 1.1.1 in library.properties so that the added support for ATTiny85 to be reflected in Library Manager of the Arduino IDE.  New tag 1.1.1 must be created from your side as well because I can not do that via a pull request. I am referring to the following paragraph as explained in https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ
"How can I publish a new release once my library is in the list?

Ensure you've changed version in your  library.properties . Then tag your library once more and push the new tag (or create a release if your web hosting offers a way to do it, for example with GitHub "releases"). Our indexer checks for new releases every hour and will eventually fetch and publish your new release."