### PR TITLE
add support for attiny167 [drAzzy core]

### DIFF
--- a/config/known_16bit_timers.h
+++ b/config/known_16bit_timers.h
@@ -107,6 +107,14 @@
   #define TIMER1_ICP_PIN 8
   #define TIMER1_CLK_PIN 5
 
+  //  attiny167
+//
+#elif defined (__AVR_ATtiny167__)
+  #define TIMER1_A_PIN   14
+  #define TIMER1_B_PIN   11
+  //#define TIMER1_ICP_PIN 8
+  //#define TIMER1_CLK_PIN 5
+  
 // Sanguino
 //
 #elif defined(__AVR_ATmega644P__) || defined(__AVR_ATmega644__)


### PR DESCRIPTION
hello Paul,

i am using with no problem your lib with the attiny167 with https://github.com/SpenceKonde/ATTinyCore

anyway:
`TCNT1 = 0;		// TODO: does this cause an undesired interrupt?`
yes, it causes an interrupt, i changed it to 1 to do a simple workaround