### PR TITLE
Added support for ATmega8

### DIFF
--- a/TimerOne.h
+++ b/TimerOne.h
@@ -170,6 +170,12 @@ class TimerOne
     static const byte ratio = (F_CPU)/ ( 1000000 );
 	
 #elif defined(__AVR__)
+
+#if defined (__AVR_ATmega8__)
+  //in some io definitions for older microcontrollers TIMSK is used instead of TIMSK1
+  #define TIMSK1 TIMSK
+#endif
+	
   public:
     //****************************
     //  Configuration
@@ -269,6 +275,7 @@ class TimerOne
     //****************************
     //  Interrupt Function
     //****************************
+	
     void attachInterrupt(void (*isr)()) __attribute__((always_inline)) {
 	isrCallback = isr;
 	TIMSK1 = _BV(TOIE1);

--- a/config/known_16bit_timers.h
+++ b/config/known_16bit_timers.h
@@ -101,7 +101,7 @@
 
 //  Uno, Duemilanove, LilyPad, etc
 //
-#elif defined (__AVR_ATmega168__) || defined (__AVR_ATmega328P__) || defined (__AVR_ATmega328__)
+#elif defined (__AVR_ATmega168__) || defined (__AVR_ATmega328P__) || defined (__AVR_ATmega328__) ||  defined (__AVR_ATmega8__)
   #define TIMER1_A_PIN   9
   #define TIMER1_B_PIN   10
   #define TIMER1_ICP_PIN 8


### PR DESCRIPTION
Some older Arduinos like the NG used the ATmega8 but this microcontroller is still a cheap alternative for custom arduino-based projects