### PR TITLE
Mega Pin 13 is on Timer 0 not Timer 1

### DIFF
--- a/config/known_16bit_timers.h
+++ b/config/known_16bit_timers.h
@@ -82,7 +82,6 @@
 #elif defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
   #define TIMER1_A_PIN   11
   #define TIMER1_B_PIN   12
-  #define TIMER1_C_PIN   13
   #define TIMER3_A_PIN   5
   #define TIMER3_B_PIN   2
   #define TIMER3_C_PIN   3


### PR DESCRIPTION
Removes incorrect pin listing for the Mega
See also https://github.com/PaulStoffregen/TimerThree/pull/9

The mega Pin 13 is on Timer 0 not Timer 1
Although the mega Timer 1 is 16 bit, it only has two pins on the timer

See issue https://github.com/PaulStoffregen/TimerThree/issues/7