### PR TITLE
Adding support for UNO-R4 boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 #TimerOne Library
 
+#delta-G Fork:
+
+This fork adds support for the UNO-R4 boards using the AGT1 timer.  PWM functions are not supported. 
+
+
 Paul Stoffregen's modified TimerOne.  This version provides 2 main benefits:
 
 1: Optimized inline functions - much faster for the most common usage  

--- a/TimerOne.cpp
+++ b/TimerOne.cpp
@@ -7,6 +7,8 @@
  *  Modified April 2012 by Paul Stoffregen
  *  Modified again, June 2014 by Paul Stoffregen
  *  Modified July 2017 by Stoyko Dimitrov - added support for ATTiny85 except for the PWM functionality
+ *  
+ *  Modified October 2023 by David Caldwell - added support for UNO-R4 boards except for the PWM functionality
  *
  *  This is free software. You can redistribute it and/or modify it under
  *  the terms of Creative Commons Attribution 3.0 United States License. 

--- a/TimerOne.cpp
+++ b/TimerOne.cpp
@@ -19,9 +19,27 @@
 
 TimerOne Timer1;              // preinstatiate
 
+
+#if defined (ARDUINO_UNOR4_MINIMA) || defined (ARDUINO_UNOR4_WIFI)
+uint16_t TimerOne::reloadSetting = 0xFFFF;
+agt_cntsrc_t TimerOne::srcbits = PCLKB;
+uint8_t TimerOne::divbits = 0;
+uint8_t TimerOne::eventLinkIndex = 0;
+void (*TimerOne::isrCallback)() = TimerOne::isrDefaultUnused;
+
+void TimerOne::internalCallback(){
+  // Reset the interrupt link and the flag for the timer
+  R_ICU->IELSR[eventLinkIndex] &= ~(R_ICU_IELSR_IR_Msk);
+  R_AGT1->AGTCR &= ~(R_AGT0_AGTCR_TUNDF_Msk);
+  isrCallback();
+}
+
+#else
 unsigned short TimerOne::pwmPeriod = 0;
 unsigned char TimerOne::clockSelectBits = 0;
 void (*TimerOne::isrCallback)() = TimerOne::isrDefaultUnused;
+
+
 
 // interrupt service routine that wraps a user defined function supplied by attachInterrupt
 #if defined (__AVR_ATtiny85__)
@@ -57,3 +75,4 @@ void TimerOne::isr(void)
 void TimerOne::isrDefaultUnused()
 {
 }
+#endif

--- a/TimerOne.h
+++ b/TimerOne.h
@@ -7,6 +7,8 @@
  *  Modified again, June 2014 by Paul Stoffregen - support Teensy 3.x & even more AVR chips
  *  Modified July 2017 by Stoyko Dimitrov - added support for ATTiny85 except for the PWM functionality
  *  
+ *  Modified October 2023 by David Caldwell - added support for UNO-R4 boards except for the PWM functionality
+ *  
  *
  *  This is free software. You can redistribute it and/or modify it under
  *  the terms of Creative Commons Attribution 3.0 United States License. 
@@ -76,7 +78,11 @@ public:
 
   static void (*isrCallback)();
   static void isrDefaultUnused(){};
+  
 
+  //****************************
+  //  Configuration
+  //****************************
   void initialize(unsigned long microseconds = 1000000) __attribute__((always_inline)) {
 
     // enable the timer in Module Stop Control Register D
@@ -185,7 +191,11 @@ public:
     R_AGT1->AGT = reloadSetting;
     start();
   }
+  
 
+  //****************************
+  //  Run Control
+  //****************************	
   void start() __attribute__((always_inline)) {
     resume();
   }
@@ -199,6 +209,15 @@ public:
     R_AGT1->AGTCR = 1;
   }
 
+  //****************************
+  //  PWM outputs
+  //****************************
+	//Not implemented yet for UNO-R4
+	//TO DO
+	
+  //****************************
+  //  Interrupt Function
+  //****************************
   void attachInterrupt(void (*isr)()) __attribute__((always_inline)) {
     isrCallback = isr;
   }

--- a/TimerOne.h
+++ b/TimerOne.h
@@ -33,16 +33,184 @@
 #define TIMER1_RESOLUTION 65536UL  // assume 16 bits for non-AVR chips
 #endif
 
+#if defined (ARDUINO_UNOR4_MINIMA) || defined (ARDUINO_UNOR4_WIFI)
+#include "IRQManager.h"
+
+#define AGT1_RESOLUTION 0xFFFF
+
+typedef enum agt_opmode_t {
+  TIMER,
+  PULSE_OUTPUT,
+  EVENT_COUNTER,
+  PULSE_WIDTH,
+  PULSE_PERIOD
+};
+
+typedef enum agt_cntsrc_t {
+  PCLKB,
+  PCLKB_8,
+  PCLKB_2 = 3,
+  AGTLCLK,
+  AGT0_UF,
+  AGTSCLK
+};
+#endif
+
 // Placing nearly all the code in this .h file allows the functions to be
 // inlined by the compiler.  In the very common case with constant values
 // the compiler will perform all calculations and simply write constants
 // to the hardware registers (for example, setPeriod).
 
+class TimerOne {
+#if defined (ARDUINO_UNOR4_MINIMA) || defined (ARDUINO_UNOR4_WIFI)
+	// Adding support for R4 UNO boards with RA4M1 chip
+private:
+  static agt_cntsrc_t srcbits;
+  static uint8_t divbits;
+  static uint16_t reloadSetting;
+  static uint8_t eventLinkIndex;
 
-class TimerOne
-{
+  static void internalCallback();
 
-#if defined (__AVR_ATtiny85__)
+public:
+
+  static void (*isrCallback)();
+  static void isrDefaultUnused(){};
+
+  void initialize(unsigned long microseconds = 1000000) __attribute__((always_inline)) {
+
+    // enable the timer in Module Stop Control Register D
+    R_MSTP->MSTPCRD &= ~(1 << R_MSTP_MSTPCRD_MSTPD2_Pos);
+    //  Make sure timer is stopped while we adjust registers.
+    R_AGT1->AGTCR = 0;
+
+    // We're using R_AGT1, but all the positions and bitmasks are defined as R_AGT0
+    // set mode register 1
+    //(-) (TCK[2:0]) (TEDGPL) (TMOD[2:0])
+    //  Use TIMER mode with the LOCO clock (best we can do since Arduino doesn't have crystal for SOSC)
+    R_AGT1->AGTMR1 = (AGTLCLK << R_AGT0_AGTMR1_TCK_Pos) | (TIMER << R_AGT0_AGTMR1_TMOD_Pos);
+    // mode register 2
+    // (LPM) (----) (CKS[2:0])
+    R_AGT1->AGTMR2 = 0;
+    // AGT I/O Control Register
+    // (TIOGT[1:0]) (TIPF[1:0]) (-) (TOE) (-) (TEDGSEL)
+    R_AGT1->AGTIOC = 0;
+    // Event Pin Select Register
+    // (-----) (EEPS) (--)
+    R_AGT1->AGTISR = 0;
+    // AGT Compare Match Function Select Register
+    // (-) (TOPOLB) (TOEB) (TCMEB) (-) (TOPOLA) (TOEA) (TCMEA)
+    R_AGT1->AGTCMSR = 0;
+    // AGT Pin Select Register
+    // (---) (TIES) (--) (SEL[1:0])
+    R_AGT1->AGTIOSEL = 0;
+    // AGT1_AGTI is the underflow event
+    //  The event code is 0x21
+
+    // Use IRQManager to attach a handler.  
+    timer_cfg_t base;
+    base.channel = 1;
+    base.cycle_end_irq = FSP_INVALID_VECTOR;
+    TimerIrqCfg_t iCfg;
+    iCfg.base_cfg = &base;
+    // to satisfy IRQManager agt_ext_cfg just has to not be null
+    agt_extended_cfg_t fake;
+    iCfg.agt_ext_cfg = &fake;
+    iCfg.gpt_ext_cfg = nullptr;
+
+    __disable_irq();
+    if (IRQManager::getInstance().addTimerOverflow(iCfg, internalCallback)) {
+      // Serial.println("Attached Interrupt.");
+      eventLinkIndex = iCfg.base_cfg->cycle_end_irq;
+      R_BSP_IrqDisable((IRQn_Type)eventLinkIndex);
+      R_BSP_IrqStatusClear((IRQn_Type)eventLinkIndex);
+      NVIC_SetPriority((IRQn_Type)eventLinkIndex, 14);
+      R_BSP_IrqEnable((IRQn_Type)eventLinkIndex);
+      // Serial.println(eventLinkIndex);
+      setPeriod(microseconds);
+    }
+    __enable_irq();
+  }
+
+  void setPeriod(unsigned long microseconds) __attribute__((always_inline)) {
+
+    // for smal periods we can use PCLKB instead of LOCO
+    divbits = 0;  // No divider bits on PCLKB
+    // PCLKB is running at SYSCLK/2 or 24MHz or 24 ticks per microsecond
+    unsigned long ticks = (24 * microseconds);
+    if (ticks < AGT1_RESOLUTION) {
+      srcbits = PCLKB;
+      reloadSetting = ticks;
+    } else if (ticks < AGT1_RESOLUTION * 2) {
+      srcbits = PCLKB_2;
+      reloadSetting = ticks / 2;
+    } else if (ticks < AGT1_RESOLUTION * 8) {
+      srcbits = PCLKB_8;
+      reloadSetting = ticks / 8;
+    } else {
+      //  Period is too long for PCLKB, use AGTLCLK (LOCO)
+      // LOCO is 32.768KHz  is (1/32768) = 30.518us/tick
+      srcbits = AGTLCLK;
+      // recalculate ticks at new clock speed
+      ticks = microseconds / (1000000.0 / 32768.0);
+      if (ticks < AGT1_RESOLUTION) {
+        divbits = 0;
+        reloadSetting = ticks;
+      } else if (ticks < AGT1_RESOLUTION * 2) {
+        divbits = 1;
+        reloadSetting = ticks / 2;
+      } else if (ticks < AGT1_RESOLUTION * 4) {
+        divbits = 2;
+        reloadSetting = ticks / 4;
+      } else if (ticks < AGT1_RESOLUTION * 8) {
+        divbits = 3;
+        reloadSetting = ticks / 8;
+      } else if (ticks < AGT1_RESOLUTION * 16) {
+        divbits = 4;
+        reloadSetting = ticks / 16;
+      } else if (ticks < AGT1_RESOLUTION * 32) {
+        divbits = 5;
+        reloadSetting = ticks / 32;
+      } else if (ticks < AGT1_RESOLUTION * 64) {
+        divbits = 6;
+        reloadSetting = ticks / 64;
+      } else if (ticks < AGT1_RESOLUTION * 128) {
+        divbits = 7;
+        reloadSetting = ticks / 128;
+      }
+    }
+    //  Use TIMER mode with the LOCO clock (best we can do since Arduino doesn't have crystal for SOSC)
+    R_AGT1->AGTMR1 = (srcbits << R_AGT0_AGTMR1_TCK_Pos) | (TIMER << R_AGT0_AGTMR1_TMOD_Pos);
+    R_AGT1->AGTMR2 = divbits;
+    R_AGT1->AGT = reloadSetting;
+    start();
+  }
+
+  void start() __attribute__((always_inline)) {
+    resume();
+  }
+  void stop() __attribute__((always_inline)) {
+    R_AGT1->AGTCR = 0;
+  }
+  void restart() __attribute__((always_inline)) {
+    start();
+  }
+  void resume() __attribute__((always_inline)) {
+    R_AGT1->AGTCR = 1;
+  }
+
+  void attachInterrupt(void (*isr)()) __attribute__((always_inline)) {
+    isrCallback = isr;
+  }
+  void attachInterrupt(void (*isr)(), unsigned long microseconds) __attribute__((always_inline)) {
+    if (microseconds > 0) setPeriod(microseconds);
+    attachInterrupt(isr);
+  }
+  void detachInterrupt() __attribute__((always_inline)) {
+    isrCallback = isrDefaultUnused;
+  }
+	
+#elif defined (__AVR_ATtiny85__)
   public:
     //****************************
     //  Configuration

--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Use hardware Timer1 for finer PWM control and/or running an periodic in
 paragraph=
 category=Timing
 url=http://playground.arduino.cc/Code/Timer1
-architectures=avr
+architectures=avr,renesas,renesas_uno
 


### PR DESCRIPTION
622ac13 will add support except for the PWM functions for the UNO-R4 boards.  There have been a number of threads mentioning problems with third party libraries that depend on TimerOne for timer functions which are broken for the R4 boards.  This pull should resolve that.  

This is my first contribution to another library.  If I'm out of line or doing it wrong, please let me know.  I really want to learn the system.  